### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/gopass.rb
+++ b/gopass.rb
@@ -1,8 +1,8 @@
 class Gopass < Formula
   desc "The slightly more awesome Standard Unix Password Manager for Teams."
   homepage "https://www.justwatch.com/gopass"
-  url "https://www.justwatch.com/gopass/releases/1.0.1/gopass-1.0.1.tar.gz"
-  sha256 "627d69aea54846e6572f5c9fa3abba2e046f96d5e0780e502c60d6a330ad8762"
+  url "https://www.justwatch.com/gopass/releases/1.1.0/gopass-1.1.0.tar.gz"
+  sha256 "5d586127a10609e3ed028690ed75648b3366af5e8c530ceb1702944b65c63281"
   head "https://github.com/justwatchcom/gopass.git"
 
   revision 1


### PR DESCRIPTION
I don't have write access to this repository :grin: 

Not sure if I need to update revision too?
But if I don't get this wrong, then this is the first revision of 1.1.0?